### PR TITLE
Fix/actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "storybook": "start-storybook -p 6006 -s ./public",
+    "build-storybook": "build-storybook -s ./public",
     "chromatic": "npx chromatic --project-token=9a7d3633eff5"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "storybook": "start-storybook -p 6006 -s ./public",
-    "build-storybook": "build-storybook -s ./public",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=9a7d3633eff5"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "build-storybook": "NODE_OPTIONS='--openssl-legacy-provider' build-storybook",
     "chromatic": "npx chromatic --project-token=9a7d3633eff5"
   },
   "dependencies": {


### PR DESCRIPTION
### 📍작업 내용

github actions를 활용하여 스토리북 배포 자동화를 시도하였지만 node 버전 문제로 다음과 같은 문제 발생

![image](https://user-images.githubusercontent.com/88662637/220858047-d1f1b66e-fe2c-4147-ac6f-8b761ca939dc.png)

따라서 `package.json`의 `build-storybook` 스크립트을 다음과 같이 수정해주었음.

`"build-storybook": "NODE_OPTIONS='--openssl-legacy-provider' build-storybook"`
