### PR TITLE
fix(map): 지도 드래깅이 되지 않는 버그 수정

### DIFF
--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -1,35 +1,23 @@
 import { mapOptions, mapStyle } from '@/config/mapConfig';
-import { useMapPanning } from '@/hooks/useMapPanning';
-import { GoogleMapProps, LocationType, Position } from '@/types/map';
+import { GoogleMapProps } from '@/types/map';
 import { GoogleMap } from '@react-google-maps/api';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
-const Map = ({ children, location, map, setMap }: GoogleMapProps) => {
-  const panTo = useMapPanning(map);
+const Map = ({ children, location, setMap }: GoogleMapProps) => {
   const onLoad = useCallback((map: google.maps.Map) => {
     setMap(map);
   }, []);
-  // const onBoundsChanged = (location: LocationType) => {
-  //   if (map) {
-  //     const bound = map.getBounds();
-
-  //     map.fitBounds(bound!);
-  //     map.
-  //   }
-  // };
 
   return (
     <GoogleMap
       onLoad={onLoad}
       zoom={14}
-      center={location.coordinates}
+      center={location}
       mapContainerStyle={mapStyle}
       options={{
         mapTypeControl: false,
         styles: mapOptions,
       }}
-      onCenterChanged={() => panTo(location)}
-      // onBoundsChanged={() => onBoundsChanged(location)}
     >
       {children}
     </GoogleMap>

--- a/src/components/maps/MapContainer.tsx
+++ b/src/components/maps/MapContainer.tsx
@@ -1,11 +1,11 @@
 import tw from 'twin.macro';
-import { useGeolocation } from '@/hooks';
-import { SubwayPosition } from '@/types/subway';
+import { useEffect, useState } from 'react';
 import { LoadScript } from '@react-google-maps/api';
-import Marker from './Marker';
-import { getLatLng } from '@/query';
-import { useState } from 'react';
-import Map from './Map';
+import { useGeolocation, useMapPanning } from '@/hooks';
+import { SubwayLocation } from '@/types/subway';
+import { getSubwayLocations } from '@/query';
+import { Marker, Map } from '@/components/maps';
+import { Location } from '@/types/map';
 
 const Wrapper = tw.div`
   min-w-[360px] h-full max-h-[90%] rounded-10
@@ -19,21 +19,24 @@ const Wrapper = tw.div`
 
 const Container = ({ line }: { line: number }) => {
   const { VITE_GOOGLE_API_KEY } = import.meta.env;
-  const [location, setLocation] = useGeolocation();
-  const subwayList: SubwayPosition[] = getLatLng({ line });
+  const [initialLocation] = useGeolocation();
+  const subwayList: SubwayLocation[] = getSubwayLocations({ line });
   const [map, setMap] = useState<google.maps.Map | null>(null);
+  const panTo = useMapPanning(map);
+
+  console.log(subwayList);
 
   return (
     <Wrapper>
       <LoadScript googleMapsApiKey={VITE_GOOGLE_API_KEY}>
-        <Map location={location} map={map} setMap={setMap}>
-          {subwayList?.map(({ position, name }) => (
+        <Map location={initialLocation} setMap={setMap}>
+          {subwayList?.map(({ location, name }) => (
             <Marker
-              position={position}
-              name={name}
               key={name}
+              location={location}
+              name={name}
               line={line}
-              setLocation={setLocation}
+              panTo={panTo}
             />
           ))}
         </Map>

--- a/src/components/maps/Marker.tsx
+++ b/src/components/maps/Marker.tsx
@@ -3,19 +3,19 @@ import { InfoBoxF, MarkerF } from '@react-google-maps/api';
 import { useState } from 'react';
 import InfoBox from './InfoBox';
 
-const Marker = ({ name, position, line, setLocation }: Info) => {
+const Marker = ({ name, location, line, panTo }: Info) => {
   const [isShown, toggleShown] = useState<boolean>(false);
 
   const handleToggle = () => {
     if (isShown) toggleShown(false);
     else {
-      setLocation({ coordinates: position });
+      panTo(location);
       toggleShown(true);
     }
   };
 
   return (
-    <MarkerF position={position} key={name} onClick={handleToggle}>
+    <MarkerF position={location} onClick={handleToggle}>
       {isShown && (
         <InfoBoxF onCloseClick={handleToggle}>
           <InfoBox line={line} name={name} />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useGeolocation } from './useGeolocation';
+export { default as useMapPanning } from './useMapPanning';

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,41 +1,59 @@
-import { LocationType } from '@/types/map';
+import { Location } from '@/types/map';
 import { useEffect, useState } from 'react';
 
 const useGeolocation = (): [
-  LocationType,
-  React.Dispatch<React.SetStateAction<LocationType>>
+  Location,
+  React.Dispatch<React.SetStateAction<Location>>
 ] => {
-  const [location, setLocation] = useState<LocationType>({
-    coordinates: {
-      lat: 0,
-      lng: 0,
-    },
+  const [location, setLocation] = useState<Location>({
+    lat: 0,
+    lng: 0,
   });
 
-  const onSuccess = (position: {
-    coords: { latitude: number; longitude: number };
-  }) => {
-    setLocation({
-      coordinates: {
-        lat: position.coords.latitude,
-        lng: position.coords.longitude,
-      },
-    });
-  };
-
-  const onError = () => {
-    setLocation({
-      coordinates: { lat: 37.56359, lng: 126.975407 },
-    });
-  };
-
   useEffect(() => {
-    if (!('geolocation' in navigator)) {
-      onError();
+    if ('geolocation' in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          setLocation({
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          });
+        },
+        () => {
+          console.log('위치를 파악하는 데에 실패했어요 !');
+          setLocation({ lat: 37.56359, lng: 126.975407 });
+        }
+      );
+    } else {
+      console.log('위치 정보 사용을 거부했어요 !');
+      setLocation({ lat: 37.56359, lng: 126.975407 });
     }
-
-    navigator.geolocation.getCurrentPosition(onSuccess, onError);
   }, []);
+
+  // const onSuccess = (position: {
+  //   coords: { latitude: number; longitude: number };
+  // }) => {
+  //   setLocation({
+  //     coordinates: {
+  //       lat: position.coords.latitude,
+  //       lng: position.coords.longitude,
+  //     },
+  //   });
+  // };
+
+  // const onError = () => {
+  //   setLocation({
+  //     coordinates: { lat: 37.56359, lng: 126.975407 },
+  //   });
+  // };
+
+  // useEffect(() => {
+  //   if (!('geolocation' in navigator)) {
+  //     onError();
+  //   }
+
+  //   navigator.geolocation.getCurrentPosition(onSuccess, onError);
+  // }, []);
 
   return [location, setLocation];
 };

--- a/src/hooks/useMapPanning.ts
+++ b/src/hooks/useMapPanning.ts
@@ -1,17 +1,17 @@
-import { LocationType } from '@/types/map';
+import { Location } from '@/types/map';
 
-export function useMapPanning(map: google.maps.Map | null) {
-  const panToLocation = (location: LocationType) => {
+const useMapPanning = (map: google.maps.Map | null) => {
+  const panToLocation = (location: Location) => {
     if (!map) {
       return;
     }
 
-    const latLng = location;
-
-    map.panTo(latLng.coordinates);
+    map.panTo(location);
   };
 
-  return (location: LocationType) => {
+  return (location: Location) => {
     panToLocation(location);
   };
-}
+};
+
+export default useMapPanning;

--- a/src/query/getSubwayLocations.ts
+++ b/src/query/getSubwayLocations.ts
@@ -1,0 +1,21 @@
+import { fetcher } from '@/api/fetcher';
+import { URLs } from '@/api/url';
+import { QueryKey } from '@/query/queryKey';
+import { useQuery } from 'react-query';
+
+const getSubwayLocations = ({ line }: { line: number }) => {
+  const { data: latLngData } = useQuery(QueryKey.LAT_LNG, () =>
+    fetcher({ path: URLs.LAT_LNG, page: 1, perPage: 2000 })
+  );
+
+  const subwayLocations = latLngData?.data
+    .filter((obj: any) => obj.호선 === line)
+    .map((item: any) => ({
+      name: `${item.역명}역`,
+      location: { lat: Number(item.위도), lng: Number(item.경도) },
+    }));
+
+  return subwayLocations;
+};
+
+export default getSubwayLocations;

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,2 +1,2 @@
 export { default as getCongestion } from './getCongestion';
-export { default as getLatLng } from './getLatLng';
+export { default as getSubwayLocations } from './getSubwayLocations';

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,22 +1,17 @@
-export type Position = {
+export type Location = {
   lat: number;
   lng: number;
 };
 
-export type LocationType = {
-  coordinates: Position;
-};
-
 export type Info = {
   name: string;
-  position: Position;
+  location: Location;
   line: number;
-  setLocation: React.Dispatch<React.SetStateAction<LocationType>>;
+  panTo: (location: Location) => void;
 };
 
 export type GoogleMapProps = {
   children: React.ReactNode;
-  location: LocationType;
-  map: google.maps.Map | null;
+  location: Location;
   setMap: React.Dispatch<React.SetStateAction<google.maps.Map | null>>;
 };

--- a/src/types/subway.ts
+++ b/src/types/subway.ts
@@ -60,7 +60,7 @@ export type RequestProps = {
   investigatedDate?: InvestigatedDate;
 };
 
-export type SubwayPosition = {
+export type SubwayLocation = {
   name: string;
-  position: { lat: number; lng: number };
+  location: { lat: number; lng: number };
 };


### PR DESCRIPTION
### 📍 작업 내용
**1. 지도 드래깅이 되지 않는 버그 수정**

`GoogleMap` 컴포넌트의 `onCenterChanged` 메서드를 이용해 마커 클릭 시 해당 위치로 화면을 이동하도록 했을 때, 지도를 드래그해도 위치가 변경되지 않는 버그가 발생하였습니다.

최초 알고리즘을 작성할 때, 마커 클릭 시 `setLocation`을 통해 `location` 상태를 변경해주었고, `location` 상태의 변경을 onCenterChanged 메서드에서 감지하여 panTo 함수를 실행시키도록 하였습니다. 하지만 드래그 할 때 지도의 `location`이 변경되는 즉시 `location` 상태가 업데이트 되고, 이로 인해 onCenterChanged 메서드가 실행되기 때문에 드래그가 되지 않는 것처럼 보였습니다.

결국 마커 클릭 시 `location`을 변경시키거나 onCenterChanged 메서드로 변화를 감지하는 것이 아니라, 해당 마커의 위치로 바로 이동할 수 있도록 `panTo` 함수를 실행시켜줌으로 문제를 해결하였습니다.

**2. 파일 구조 및 파일명/변수명 리팩토링**

`location` 상태는 { coordinates: {lat, lng}} 와 같은 형태로 저장되어 있었습니다. 하지만 `coordinates`라는 키 값은 사용되지 않고 value인 `{ lat, lng }`만 사용되었기 때문에 `useGeolocation` 함수의 반환값을 조정하였습니다. 

이로 인해 사용되지 않는 `LocationType` 타입을 제거하고, 명확하게 타입을 유추할 수 있도록 `Position`의 타입명을 `Location`으로 변경하였습니다.

