### PR TITLE
Feat/time

### DIFF
--- a/src/hooks/useTime.ts
+++ b/src/hooks/useTime.ts
@@ -1,7 +1,23 @@
+const padZero = (time: number) => {
+  return time.toString().padStart(2, '0');
+  // return ('0' + time).slice(-2); 뭐가 더 효율적일까?
+};
+
 const useTime = () => {
   const date = new Date();
-  console.log(date);
-  return null;
+  let hour = date.getHours();
+  let minute = date.getMinutes();
+
+  if (minute >= 45) {
+    minute = 0;
+    hour++;
+  } else if (minute >= 15) {
+    minute = 30;
+  } else {
+    minute = 0;
+  }
+
+  return `${padZero(hour)}시${padZero(minute)}분`;
 };
 
 export default useTime;

--- a/src/hooks/useTime.ts
+++ b/src/hooks/useTime.ts
@@ -1,12 +1,14 @@
-const padZero = (time: number) => {
-  return time.toString().padStart(2, '0');
-  // return ('0' + time).slice(-2); 뭐가 더 효율적일까?
-};
+import { useCallback, useMemo } from 'react';
 
 const useTime = () => {
-  const date = new Date();
-  let hour = date.getHours();
-  let minute = date.getMinutes();
+  const getTimeString = useCallback((time: number) => {
+    return time.toString().padStart(2, '0');
+    // return ('0' + time).slice(-2); 뭐가 더 효율적일까?
+  }, []);
+
+  const now = useMemo(() => new Date(), []);
+  let hour = now.getHours();
+  let minute = now.getMinutes();
 
   if (minute >= 45) {
     minute = 0;
@@ -17,7 +19,13 @@ const useTime = () => {
     minute = 0;
   }
 
-  return `${padZero(hour)}시${padZero(minute)}분`;
+  const hourString = useMemo(() => getTimeString(hour), [getTimeString, hour]);
+  const minuteString = useMemo(
+    () => getTimeString(minute),
+    [getTimeString, minute]
+  );
+
+  return `${hourString}시${minuteString}분`;
 };
 
 export default useTime;

--- a/src/hooks/useTime.ts
+++ b/src/hooks/useTime.ts
@@ -1,0 +1,7 @@
+const useTime = () => {
+  const date = new Date();
+  console.log(date);
+  return null;
+};
+
+export default useTime;


### PR DESCRIPTION
### 📍 작업 내용
시간을 30분 단위로 나누고, 현재 시간과 가장 가까운 지점의 지하철 혼잡도를 출력합니다.

`String` 형식을 `SubwayCongestion` 인덱스 형식에 사용할 수 없다는 에러가 발생하였습니다. 그래서 `SubwayCongestion` 타입에서 사용되는 리터럴 타입이 `String` 형식임을 의도적으로 명시해주었습니다.