### PR TITLE
refactor(gnb): 스타일 수정 및 컴포넌트 구조 변경

### DIFF
--- a/src/assets/icons/icon-chevron-down.svg
+++ b/src/assets/icons/icon-chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+</svg>

--- a/src/components/common/Gnb/Gnb.tsx
+++ b/src/components/common/Gnb/Gnb.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import tw, { styled } from 'twin.macro';
 import Menu from './Menu';
 
@@ -11,30 +11,30 @@ const Navigation = styled.nav([
 
 const MenuContainer = styled.div<{ open: boolean }>(({ open }) => [
   tw`fixed left-2 top-2 duration-150`,
-  tw`flex flex-col h-[99.5%] bg-gray-200 rounded-8`,
+  tw`flex flex-col h-[99.5%] bg-gray-200 rounded-8 z-50 cursor-pointer`,
 
-  open ? tw`w-200` : tw`w-70`,
+  open ? tw`w-[220px]` : tw`w-70`,
 
   tw`[svg]:(box-content duration-100 rounded-7 p-10 m-0 hover:(bg-gray-400))`,
+  tw`[li > div > svg]:(p-5 hover:(bg-transparent))`,
 ]);
 
 const MenuTop = styled.div([
-  tw`flex-center mx-20 my-10 pb-10 w-28 border-b-1 border-gray-500`,
+  tw`flex-center m-10 pb-10 border-b-1 border-gray-500`,
 ]);
 
-const List = styled.ul<{ open: boolean }>(({ open }) => [
+const List = styled.div<{ open: boolean }>(({ open }) => [
   tw`px-10 my-20 flex flex-col gap-5`,
 
-  tw`[p]:px-10`,
-  tw`[> li]:(flex justify-start items-center pr-10 opacity-[.01])`,
+  tw`[li]:(flex justify-start items-center pr-10 opacity-[.01])`,
 
   open ? tw`[li]:(opacity-100 delay-150)` : tw`[li]:delay-[0]`,
 ]);
 
 const Gnb = () => {
   const [open, setOpen] = useState<boolean>(false);
-  const onMouseOver = () => setOpen(true);
-  const onMouseLeave = () => setOpen(false);
+  const onMouseOver = useCallback(() => setOpen(true), [setOpen]);
+  const onMouseLeave = useCallback(() => setOpen(false), [setOpen]);
 
   return (
     <Navigation onMouseOver={onMouseOver} onMouseLeave={onMouseLeave}>
@@ -48,18 +48,19 @@ const Gnb = () => {
           />
         </MenuTop>
         <List open={open}>
-          <li>
-            <Menu icon={'metro'} width={28} height={28} strokeWidth={1.5} />
-            <p>지하철 혼잡도</p>
-          </li>
-          <li>
-            <Menu icon={'people'} width={28} height={28} />
-            <p>사람들</p>
-          </li>
-          <li>
-            <Menu icon={'map'} width={28} height={28} />
-            <p>지도</p>
-          </li>
+          <ul>
+            <li>
+              <Menu icon={'metro'} width={28} height={28} title='지하철 혼잡도'>
+                {[1, 2, 3, 4, 5]}
+              </Menu>
+            </li>
+            <li>
+              <Menu icon={'people'} width={28} height={28} title='사람들' />
+            </li>
+            <li>
+              <Menu icon={'map'} width={28} height={28} title='지도' />
+            </li>
+          </ul>
         </List>
       </MenuContainer>
     </Navigation>

--- a/src/components/common/Gnb/Menu.tsx
+++ b/src/components/common/Gnb/Menu.tsx
@@ -1,4 +1,7 @@
 import SvgIcon from '@/components/common/Icon/SvgIcon';
+import { ReactComponent as DownIcon } from '@/assets/icons/icon-chevron-down.svg';
+import { ReactNode } from 'react';
+import tw from 'twin.macro';
 
 const Menu = ({
   icon,
@@ -6,14 +9,28 @@ const Menu = ({
   height,
   strokeWidth = 1.2,
   styles,
+  title,
+  children,
 }: {
   icon: string;
   width: number;
   height: number;
   strokeWidth?: number;
+  title?: string;
   styles?: any;
+  children?: ReactNode;
 }) => {
-  return <div css={styles}>{SvgIcon[icon](width, height, strokeWidth)}</div>;
+  return (
+    <div css={[tw`flex justify-between items-center w-full`]}>
+      <div css={tw`flex justify-center items-center`}>
+        <div css={[styles]}>{SvgIcon[icon](width, height, strokeWidth)}</div>
+        <p css={tw`p-10`}>{title}</p>
+      </div>
+      {children && (
+        <DownIcon width={12} height={12} css={tw`p-0 hover:(bg-current)`} />
+      )}
+    </div>
+  );
 };
 
 export default Menu;

--- a/src/components/common/Icon/SvgIcon.tsx
+++ b/src/components/common/Icon/SvgIcon.tsx
@@ -2,6 +2,7 @@ import { ReactComponent as BarsIcon } from '@/assets/icons/icon-bars.svg';
 import { ReactComponent as MapIcon } from '@/assets/icons/icon-map.svg';
 import { ReactComponent as PeopleIcon } from '@/assets/icons/icon-people.svg';
 import { ReactComponent as MetroIcon } from '@/assets/icons/icon-metro.svg';
+import { ReactComponent as DownIcon } from '@/assets/icons/icon-chevron-down.svg';
 import { ReactNode } from 'react';
 
 const SvgIcon: {
@@ -22,6 +23,9 @@ const SvgIcon: {
   ),
   metro: (width, height, strokeWidth) => (
     <MetroIcon width={width} height={height} strokeWidth={strokeWidth} />
+  ),
+  down: (width, height, strokeWidth) => (
+    <DownIcon width={width} height={height} strokeWidth={strokeWidth} />
   ),
 };
 


### PR DESCRIPTION
### 📍 작업 내용
1. `gnb` 컴포넌트의 스타일을 수정합니다.
2. `menu` 컴포넌트에서 메뉴 타이틀을 관리하도록 props를 넘겨줍니다.
3. `menu` 컴포넌트에 자식 컴포넌트가 존재할 경우 `chevron-down` 아이콘을 렌더링합니다. 