### PR TITLE
fix(map): 드래그 옵션 테스트 - greedy

### DIFF
--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -17,6 +17,7 @@ const Map = ({ children, location, setMap }: GoogleMapProps) => {
       options={{
         mapTypeControl: false,
         styles: mapOptions,
+        gestureHandling: 'greedy',
       }}
     >
       {children}

--- a/src/config/mapConfig.ts
+++ b/src/config/mapConfig.ts
@@ -8,6 +8,7 @@ export const mapOptions = [
   {
     featureType: 'poi',
     elementType: 'labels',
+    gestureHandling: 'greedy',
     stylers: [{ visibility: 'off' }],
   },
 ];

--- a/src/config/mapConfig.ts
+++ b/src/config/mapConfig.ts
@@ -8,7 +8,6 @@ export const mapOptions = [
   {
     featureType: 'poi',
     elementType: 'labels',
-    gestureHandling: 'greedy',
     stylers: [{ visibility: 'off' }],
   },
 ];


### PR DESCRIPTION
### 📍 작업 내용
모바일에서 접속 시 지도 드래그를 위해 두 손가락을 이용해야 하는 불편함이 존재합니다.
때문에, 이를 한 손가락으로 변경하기 위해 옵션을 수정하고 모바일 기기에서 테스트를 합니다. 