### PR TITLE
style(mobile): 반응형을 고려한 스타일 추가

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -21,13 +21,13 @@ const getButtonType: Record<ButtonType, TwStyle> = {
 };
 
 const getButtonSize: Record<ButtonSize, TwStyle> = {
-  large: tw`px-24 py-16`,
-  medium: tw` px-16 py-14`,
-  small: tw`px-8 py-8`,
+  large: tw`px-24pxr py-16pxr`,
+  medium: tw` px-16pxr py-14pxr`,
+  small: tw`px-8pxr py-8pxr`,
 };
 
 const BASE_STYLE = [
-  tw`rounded-2 max-w-full w-65`,
+  tw`rounded-2 max-w-full w-65pxr`,
   tw`cursor-pointer block truncate`,
   tw`bg-white text-black font-bold `,
 ];

--- a/src/components/common/Gnb/Gnb.tsx
+++ b/src/components/common/Gnb/Gnb.tsx
@@ -4,8 +4,7 @@ import Menu from './Menu';
 
 const Navigation = styled.nav([
   tw`
-  relative min-w-70
-  mobile:(hidden)
+  relative min-w-70 hidden
   laptop:(flex-stack bg-white)`,
 ]);
 

--- a/src/components/maps/MapContainer.tsx
+++ b/src/components/maps/MapContainer.tsx
@@ -6,11 +6,11 @@ import { SubwayLocationObj } from '@/types/subway';
 import { Marker, Map } from '@/components/maps';
 
 const Wrapper = tw.div`
-  min-w-[400px] h-full rounded-10 overflow-y-hidden
+  h-full rounded-10 overflow-y-hidden
   shadow-gray-300 drop-shadow-lg
   flex-center flex-1
-
-  mobile:(w-full)
+  w-full max-w-[100%]
+  laptop:max-w-[55%]
   `;
 
 const MapContainer = ({

--- a/src/components/maps/infos/InfoContainer.tsx
+++ b/src/components/maps/infos/InfoContainer.tsx
@@ -1,5 +1,5 @@
 import tw from 'twin.macro';
-import { useDayOfWeek, useTime } from '@/hooks';
+import { useTime } from '@/hooks';
 import { useRecoilValue } from 'recoil';
 import { getCongestion } from '@/query';
 import { Info, Skeleton } from '.';

--- a/src/components/subway/Days.tsx
+++ b/src/components/subway/Days.tsx
@@ -12,12 +12,12 @@ const Days = () => {
   };
 
   return (
-    <div tw='inline-flex' role='group'>
+    <div tw='tablet:(flex-row) flex-stack mb-20' role='group'>
       <Button
         onClick={handleDays}
         type={days === '평일' ? 'primary' : 'default'}
         size='small'
-        props={[tw`text-14 mb-20`]}
+        props={[tw`text-sm`]}
       >
         평일
       </Button>
@@ -25,7 +25,7 @@ const Days = () => {
         onClick={handleDays}
         type={days === '토요일' ? 'primary' : 'default'}
         size='small'
-        props={[tw`text-14 mb-20`]}
+        props={[tw`text-sm`]}
       >
         토요일
       </Button>

--- a/src/components/subway/SubwayList.tsx
+++ b/src/components/subway/SubwayList.tsx
@@ -4,12 +4,12 @@ import tw, { styled } from 'twin.macro';
 import { SubwayName, Days } from '.';
 
 const Container = styled.section([
-  tw`mobile:(w-full h-auto)`,
-  tw`laptop:(flex flex-col justify-start items-start min-w-[150px] max-w-[450px] w-full h-full rounded-10 mr-40 pr-20)`,
+  tw`w-full h-auto`,
+  tw`laptop:(flex flex-col justify-start items-start min-w-[150px] max-w-[350px] w-full h-full rounded-10 mr-20)`,
 ]);
 
 const List = tw.div`
-  py-10 pr-40 w-full
+  py-10 pr-20 w-full
 `;
 
 const SubwayList = ({
@@ -27,8 +27,7 @@ const SubwayList = ({
       </div>
       <div
         css={[
-          tw`flex flex-col justify-start overflow-y-scroll`,
-          tw`mobile:(hidden)`,
+          tw`flex flex-col justify-start overflow-y-scroll hidden`,
           tw`laptop:(flex flex-col justify-start gap-20 h-full w-full pt-10 rounded-5 mt-20)`,
         ]}
       >

--- a/src/components/subway/SubwayName.tsx
+++ b/src/components/subway/SubwayName.tsx
@@ -8,8 +8,7 @@ import { lineState } from '@/recoil/atoms/lineState';
 const TopContainer = styled.div([
   tw`relative flex items-center cursor-pointer`,
   tw`hover:([svg]:animate-bounce)`,
-
-  tw`mobile:p-0 mb-20`,
+  tw`p-0 mb-20`,
   tw`laptop:p-0`,
 ]);
 

--- a/src/pages/CongestionPage.tsx
+++ b/src/pages/CongestionPage.tsx
@@ -13,7 +13,7 @@ const CongestionPage = () => {
   return (
     <div
       css={[
-        tw`mobile:(flex-stack w-full h-5/6)`,
+        tw`flex-stack w-full h-5/6`,
         tw`laptop:(flex flex-row justify-around items-center gap-20 w-full h-5/6)`,
       ]}
     >

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,17 +1,15 @@
 import { useEffect } from 'react';
 import { Gnb } from '@/components/common/Gnb';
 import tw from 'twin.macro';
-import CongestionPage from './CongestionPage';
 import { Outlet } from 'react-router-dom';
 
 const Wrapper = tw.div`h-screen flex-center`;
 
 const MainSection = tw.section`
-  w-2/3 h-4/5 min-w-[440px] min-h-[500px] rounded-10 pr-40
+  w-2/3 h-4/5 min-w-[280px] min-h-[500px] rounded-10 pr-40
   bg-white drop-shadow-lg
   flex items-center flex-row justify-between 
-
-  mobile:(px-40)
+  px-40
 `;
 
 const MainPage = () => {

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -12,12 +12,12 @@ export const customStyles = css({
     },
   ],
 
-  h1: tw`font-Bold text-56 text-black leading-64`,
-  h2: tw`font-Bold text-48 text-black leading-56`,
-  h3: tw`font-Bold text-40 text-black leading-48`,
-  h4: tw`font-Bold text-32 text-black leading-40`,
-  h5: tw`font-Bold text-24 text-black leading-32`,
-  h6: tw`font-Bold text-18 text-black leading-26`,
+  h1: tw`font-Bold text-6xl text-black leading-64`,
+  h2: tw`font-Bold text-5xl text-black leading-56`,
+  h3: tw`font-Bold text-4xl text-black leading-48`,
+  h4: tw`font-Bold text-3xl text-black leading-40`,
+  h5: tw`font-Bold text-2xl text-black leading-32`,
+  h6: tw`font-Bold text-xl text-black leading-26`,
 });
 
 const GlobalStyles = () => (


### PR DESCRIPTION
### 📍 작업 내용
- 모든 컴포넌트의 기본 스타일을 모바일 기준으로 작성합니다.
- 정적 사이즈 `px`를 `rem`으로 일부 수정합니다.
- 이외에도 MainPage의 min-width, MapContainer의 min-width 등을 수정합니다.