### PR TITLE
fix: gnb를 열었을 때 subwayList에 가려지는 버그 수정

### DIFF
--- a/src/components/subway/SubwayList.tsx
+++ b/src/components/subway/SubwayList.tsx
@@ -34,7 +34,7 @@ const SubwayList = ({
         css={[
           tw`flex flex-col justify-start`,
           tw`scrollbar scrollbar-thumb-gray-600 scrollbar-w-4 scrollbar-thumb-rounded-2 scrollbar-track-transparent`,
-          tw`absolute transition-all w-full bottom-0 left-0 rounded-t-10 z-50`,
+          tw`absolute transition-all w-full bottom-0 left-0 rounded-t-10 z-30`,
 
           clicked ? tw`bg-white h-[600px]` : tw`h-50 opacity-[0.01]`,
 


### PR DESCRIPTION
### 📍 작업 내용
subwayList의 z-index를 수정하여 gnb를 가리지 않도록 수정합니다.